### PR TITLE
Set Slider tabIndex to -1 when disabled

### DIFF
--- a/components/slider/Slider.js
+++ b/components/slider/Slider.js
@@ -294,7 +294,7 @@ const factory = (ProgressBar, Input) => {
           onBlur={this.handleSliderBlur}
           onFocus={this.handleSliderFocus}
           style={this.props.style}
-          tabIndex="0"
+          tabIndex={this.props.disabled ? -1 : 0}
         >
           <div
             ref={(node) => { this.sliderNode = node; }}


### PR DESCRIPTION
This change sets `tabIndex` to `-1` when the Slider is disabled to prevent it from gaining focus when navigating with the keyboard.